### PR TITLE
🩹 Fix pandas future warning when calling TimeResolved.smoothed_intensity()

### DIFF
--- a/src/tlab_analysis/photo_luminescence.py
+++ b/src/tlab_analysis/photo_luminescence.py
@@ -370,7 +370,9 @@ class TimeResolved:
             A Series object of the smoothed intensity.
         """
         assert "intensity" in self.df.columns
-        return self.df.rolling(window, center=True).mean()["intensity"]
+        intensity = self.df["intensity"].rolling(window, center=True).mean()
+        assert isinstance(intensity, pd.Series)
+        return intensity
 
 
 @dataclasses.dataclass(frozen=True)


### PR DESCRIPTION
When `TimeResolved.smoothed_intensity()` is called after a string column is added to `TimeResolved.df`, pandas gives a future warning.

## Reproducible code
```python
import numpy as np

import tlab_analysis.photo_luminescence as pl

np.random.seed(0)

data = pl.Data(
    time=np.linspace(0, 10, 480),
    wavelength=np.linspace(435, 535, 640),
    intensity=np.random.randint(10, 30, 480 * 640).astype(dtype=np.float32)
)
tr = data.resolve_along_time()
tr.df["str_col"] = "foo"
tr.smoothed_intensity()
```
The script results in:
/workspaces/tlab-analysis/src/tlab_analysis/photo_luminescence.py:373: FutureWarning: Dropping of nuisance columns in rolling operations is deprecated; in a future version this will raise TypeError. Select only valid columns before calling the operation. Dropped columns were Index(['str_col'], dtype='object')
  return self.df.rolling(window, center=True).mean()["intensity"]

## Version
v0.0.1

