### PR TITLE
🏷️ Fix deprecated types in `typing`

### DIFF
--- a/src/tlab_analysis/photo_luminescence.py
+++ b/src/tlab_analysis/photo_luminescence.py
@@ -5,6 +5,7 @@ import functools
 import io
 import os
 import typing as t
+from collections import abc
 
 import numpy as np
 import numpy.typing as npt
@@ -457,7 +458,7 @@ class WavelengthResolved:
 
     def fit(
         self,
-        func: t.Callable[[t.Any], t.Any],
+        func: abc.Callable[[t.Any], t.Any],
         fitting_range: tuple[float, float] | None = None,
         **kwargs: t.Any,
     ) -> tuple[t.Any, t.Any]:  # pragma: no cover

--- a/src/tlab_analysis/utils.py
+++ b/src/tlab_analysis/utils.py
@@ -1,11 +1,11 @@
-import typing as t
+from collections import abc
 
 import pandas as pd
 
 
 def find_scdc(  # SCDC: the Start Coordinates of a Decay Curve
-    xdata: t.Sequence[float | int],
-    ydata: t.Sequence[float | int],
+    xdata: abc.Sequence[float | int],
+    ydata: abc.Sequence[float | int],
     _window: int = 10,
     _k: int = 2,
 ) -> tuple[float, float]:
@@ -67,8 +67,8 @@ def find_scdc(  # SCDC: the Start Coordinates of a Decay Curve
 
 
 def determine_fit_range_dc(
-    xdata: t.Sequence[float | int],
-    ydata: t.Sequence[float | int],
+    xdata: abc.Sequence[float | int],
+    ydata: abc.Sequence[float | int],
     _alpha: float = 0.10,
 ) -> tuple[float, float]:
     """

--- a/tests/test_photo_luminescence.py
+++ b/tests/test_photo_luminescence.py
@@ -1,5 +1,6 @@
 import io
 import typing as t
+from collections import abc
 from unittest import mock
 
 import numpy as np
@@ -146,7 +147,7 @@ def describe_data() -> None:
         assert wr.data == data
 
     @pytest.fixture()
-    def find_scdc_mock() -> t.Generator[mock.Mock, None, None]:
+    def find_scdc_mock() -> abc.Generator[mock.Mock, None, None]:
         with mock.patch("tlab_analysis.utils.find_scdc", return_value=(1.0, 1.0)) as m:
             yield m
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-import typing as t
+from collections import abc
 
 import numpy as np
 import pytest
@@ -11,7 +11,7 @@ from tlab_analysis import utils
 @pytest.fixture(params=["length_not_equal", "empty"])
 def invalid_xdata_and_ydata(
     request: FixtureRequest[str],
-) -> tuple[t.Sequence[float], t.Sequence[float]]:
+) -> tuple[abc.Sequence[float], abc.Sequence[float]]:
     match request.param:
         case "length_not_equal":
             return [0.0], [0.0, 0.0]
@@ -39,7 +39,7 @@ def test_find_scdc(x0: float, y0: float, tau: float, seed: int) -> None:
 
 
 def test_find_scdc_ValueError(
-    invalid_xdata_and_ydata: tuple[t.Sequence[float], t.Sequence[float]]
+    invalid_xdata_and_ydata: tuple[abc.Sequence[float], abc.Sequence[float]]
 ) -> None:
     xdata, ydata = invalid_xdata_and_ydata
     with pytest.raises(ValueError):
@@ -67,7 +67,7 @@ def test_determine_fit_range_dc(x0: float, tau: float, seed: int) -> None:
 
 
 def test_determine_fit_range_dc_ValueError(
-    invalid_xdata_and_ydata: tuple[t.Sequence[float], t.Sequence[float]]
+    invalid_xdata_and_ydata: tuple[abc.Sequence[float], abc.Sequence[float]]
 ) -> None:
     xdata, ydata = invalid_xdata_and_ydata
     with pytest.raises(ValueError):


### PR DESCRIPTION
- Fix `typing.Sequence` to `collections.abc.Sequence`
- Fix `typing.Generator` to `collections.abc.Generator`
- Fix `typing.Callable` to `collections.abc.Callable`